### PR TITLE
Use bleak-retry-connector establish_connection for BLE setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install requirements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build draft release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
       - name: get properties
         id: manifest
         uses: ActionsTools/read-json-action@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Run hassfest validation
         uses: home-assistant/actions/hassfest@master

--- a/custom_components/volcano_hybrid/manifest.json
+++ b/custom_components/volcano_hybrid/manifest.json
@@ -1,17 +1,28 @@
 {
   "domain": "volcano_hybrid",
   "name": "Volcano Hybrid",
-  "bluetooth": [{
-    "manufacturer_id": 1736,
-    "local_name": "S&B VOLCANO*"
-  }],
-  "codeowners": ["@SavageNL"],
+  "bluetooth": [
+    {
+      "manufacturer_id": 1736,
+      "local_name": "S&B VOLCANO*"
+    }
+  ],
+  "codeowners": [
+    "@SavageNL"
+  ],
   "config_flow": true,
-  "dependencies": ["bluetooth_adapters"],
+  "dependencies": [
+    "bluetooth_adapters"
+  ],
   "documentation": "https://github.com/SavageNL/home-assistant-volcano-hybrid",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/SavageNL/home-assistant-volcano-hybrid/issues",
-  "loggers": ["volcano_hybrid"],
-  "requirements": ["bleak>=0.20.2", "bleak-retry-connector>=3.0.2"],
+  "loggers": [
+    "volcano_hybrid"
+  ],
+  "requirements": [
+    "bleak>=2.1.1",
+    "bleak-retry-connector>=4.6.0"
+  ],
   "version": "1.0.3"
 }

--- a/custom_components/volcano_hybrid/manifest.json
+++ b/custom_components/volcano_hybrid/manifest.json
@@ -12,6 +12,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/SavageNL/home-assistant-volcano-hybrid/issues",
   "loggers": ["volcano_hybrid"],
-  "requirements": ["bleak>=0.20.2"],
-  "version": "1.0.2"
+  "requirements": ["bleak>=0.20.2", "bleak-retry-connector>=3.0.2"],
+  "version": "1.0.3"
 }

--- a/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
+++ b/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, TypeVar
 from bleak import BleakClient, BleakError, BleakGATTCharacteristic, BLEDevice
 from bleak.backends.service import BleakGATTService
 from bleak_retry_connector import (
+    BleakClientWithServiceCache,
     BleakNotFoundError,
     establish_connection,
 )
@@ -144,7 +145,7 @@ class VolcanoBLE(VolcanoHybridDataStatusProvider):
         try:
             _LOGGER.debug("Connecting to BLE device at %s", self.device.address)
             self.client = await establish_connection(
-                BleakClient,
+                BleakClientWithServiceCache,
                 self.device,
                 "Volcano Hybrid",
                 disconnected_callback=self._disconnected,
@@ -181,6 +182,7 @@ class VolcanoBLE(VolcanoHybridDataStatusProvider):
     def _disconnected(self, client: BleakClient) -> None:
         """Handle disconnection events."""
         _LOGGER.debug("Disconnected from BLE device at %s", client.address)
+        self.client = None
         self._after_data_updated()
 
     async def _async_read_and_subscribe_all(self) -> VolcanoHybridData:

--- a/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
+++ b/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING, TypeVar
 
 from bleak import BleakClient, BleakError, BleakGATTCharacteristic, BLEDevice
 from bleak.backends.service import BleakGATTService
+from bleak_retry_connector import (
+    BleakNotFoundError,
+    establish_connection,
+)
 from habluetooth import BluetoothServiceInfoBleak
 
 from .volcano_hybrid_data import VolcanoHybridData, VolcanoHybridDataStatusProvider
@@ -128,23 +132,48 @@ class VolcanoBLE(VolcanoHybridDataStatusProvider):
         return self.data
 
     async def _ensure_client_connected(self) -> bool:
-        """Ensure the BLE client is initialized and connected."""
-        try:
-            if not self.device:
-                _LOGGER.error("No last service info available, unable to connect")
-                return False
+        """Ensure the BLE client is initialized and connected.
 
-            if not self.client:
-                self.client = BleakClient(self.device, self._disconnected)
-            if not self.client.is_connected:
-                _LOGGER.debug("Connecting to BLE device at %s", self.device.address)
-                await self.client.connect()
-                self._after_data_updated()
-                await self._async_read_and_subscribe_all()
+        Uses bleak_retry_connector.establish_connection() so connection
+        attempts get retry/backoff behavior tuned for HA's bluetooth stack
+        (the proxy fleet, GATT contention, transient disconnects). A
+        previously-disconnected client is replaced by a fresh connected
+        one — never reused — which avoids "BleakClient.connect() called
+        without bleak-retry-connector" warnings from habluetooth.
+        """
+        if not self.device:
+            _LOGGER.error("No last service info available, unable to connect")
+            return False
+
+        if self.is_connected:
+            self._determine_connected_device()
+            return True
+
+        try:
+            _LOGGER.debug("Connecting to BLE device at %s", self.device.address)
+            self.client = await establish_connection(
+                BleakClient,
+                self.device,
+                "Volcano Hybrid",
+                disconnected_callback=self._disconnected,
+            )
+        except BleakNotFoundError as err:
+            _LOGGER.debug("BLE device not found while connecting: %s", err)
+            await self.async_disconnect()
+            return False
         except BleakError as err:
             _LOGGER.debug("Failed to connect to BLE device: %s", err)
             await self.async_disconnect()
             return False
+
+        self._after_data_updated()
+        try:
+            await self._async_read_and_subscribe_all()
+        except BleakError as err:
+            _LOGGER.debug("Failed to read/subscribe after connect: %s", err)
+            await self.async_disconnect()
+            return False
+
         self._determine_connected_device()
         return True
 

--- a/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
+++ b/custom_components/volcano_hybrid/volcano_ble/volcano_ble.py
@@ -132,15 +132,7 @@ class VolcanoBLE(VolcanoHybridDataStatusProvider):
         return self.data
 
     async def _ensure_client_connected(self) -> bool:
-        """Ensure the BLE client is initialized and connected.
-
-        Uses bleak_retry_connector.establish_connection() so connection
-        attempts get retry/backoff behavior tuned for HA's bluetooth stack
-        (the proxy fleet, GATT contention, transient disconnects). A
-        previously-disconnected client is replaced by a fresh connected
-        one — never reused — which avoids "BleakClient.connect() called
-        without bleak-retry-connector" warnings from habluetooth.
-        """
+        """Ensure the BLE client is initialized and connected."""
         if not self.device:
             _LOGGER.error("No last service info available, unable to connect")
             return False

--- a/custom_components/volcano_hybrid/volcano_ble/volcano_hybrid_data.py
+++ b/custom_components/volcano_hybrid/volcano_ble/volcano_hybrid_data.py
@@ -150,12 +150,12 @@ class VolcanoHybridData:
         return self.set_temp_write if self.set_temp_write is not None else self.set_temp
 
     @property
-    def set_temp(self) -> bool | None:
+    def set_temp(self) -> int | None:
         """Return the current set_temp state."""
         return self._set_temp
 
     @set_temp.setter
-    def set_temp(self, value: bool) -> None:
+    def set_temp(self, value: int) -> None:
         """Set the current set_temp state (and clears the write if they match)."""
         self._set_temp = value
         if self.set_temp_write is not None and self.set_temp == self.set_temp_write:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Volcano Hybrid",
-    "homeassistant": "2025.2.4",
+    "homeassistant": "2026.4.0",
     "hacs": "2.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.10.1
-homeassistant==2025.5.0
+homeassistant==2026.5.0
 pip>=21.3.1
 ruff==0.14.5
-habluetooth>=3.37.0
-bleak~=1.1.1
+habluetooth>=5.11.1
+bleak~=2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.10.1
 homeassistant==2026.5.0
 pip>=21.3.1
-ruff==0.14.5
+ruff==0.15.1
 habluetooth>=5.11.1
 bleak~=2.1.1


### PR DESCRIPTION
## Problem

Running this integration on Home Assistant Core 2026.4.2 with ESPHome `bluetooth_proxy` peripherals produces a recurring warning every time `_ensure_client_connected` reconnects:

> `BleakClient.connect() called without bleak-retry-connector, this can lead to connection failures`

Source: `custom_components/volcano_hybrid/volcano_ble/volcano_ble.py:141` (the `await self.client.connect()` call inside `_ensure_client_connected`). HA's `system_log/list` showed it persisted across restarts (count > 1 per session in my testing).

The warning is benign in itself, but the underlying behavior — direct `BleakClient.connect()` — also bypasses the retry/backoff that `bleak-retry-connector` is designed to add on top of HA's bluetooth stack. With BLE proxies, GATT contention and transient disconnects are common, and `establish_connection()` is the path HA expects integrations to take.

## Fix

Switch `_ensure_client_connected` to `bleak_retry_connector.establish_connection`, which:

- Returns a fresh, already-connected client. The existing code only enters this path when `is_connected` is `False`, so we can replace the local client wholesale rather than reusing one.
- Takes a connection name (`\"Volcano Hybrid\"`) so HA's bluetooth diagnostics attribute slow connects back to this integration.
- Accepts the existing `_disconnected` callback as `disconnected_callback`, so disconnect handling is unchanged.
- Lets us treat `BleakNotFoundError` as a clean \"retry later\" signal (logged at debug rather than error), so a momentarily-out-of-range device doesn't spam the log every poll cycle.

`bleak-retry-connector>=3.0.2` is added to `manifest.json` requirements (that's the floor that ships `establish_connection` with the keyword args used here). Manifest version bumped 1.0.2 → 1.0.3.

## Validation

Tested against a real Volcano Hybrid behind two ESPHome `bluetooth_proxy` peripherals on HA Core 2026.4.2:

- `ha core check` — passes
- After `ha core restart`, `binary_sensor.volcano_hybrid_connected` returns to `on`
- `system_log/list` no longer reports the BleakClient warning
- Read/subscribe of metadata characteristics still completes (firmware/serial/etc. populate, fan/heater/temperature update normally)

## Notes

Drafting because I'd like a maintainer to sanity-check whether the `BleakNotFoundError` log-level demotion is in line with how you'd like the integration to behave when the device is out of range — happy to revert that hunk if you'd prefer to keep error-level logging there. The core `establish_connection` swap is the load-bearing change.